### PR TITLE
Different/configurable distance metrics

### DIFF
--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,0 +1,1 @@
+__author__ = 'willmcginnis'

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,1 +1,1 @@
-__author__ = 'willmcginnis'
+

--- a/benchmark/table_perf.py
+++ b/benchmark/table_perf.py
@@ -1,0 +1,33 @@
+"""
+A helper script for evaluating performance of changes to the tabular explainer, in this case different
+implementations and methods for distance calculation.
+"""
+
+import time
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.datasets import make_classification
+from lime.lime_tabular import LimeTabularExplainer
+
+
+def interpret_data(X, y, func):
+    explainer = LimeTabularExplainer(X, discretize_continuous=False, kernel_width=3)
+    times, scores = [], []
+    for r_idx in range(100):
+        start_time = time.time()
+        explanation = explainer.explain_instance(X[r_idx, :], func)
+        times.append(time.time() - start_time)
+        scores.append(explanation.score)
+        print('...')
+
+    return times, scores
+
+
+if __name__ == '__main__':
+    X_raw, y_raw = make_classification(n_classes=2, n_features=1000, n_samples=1000)
+    clf = RandomForestClassifier()
+    clf.fit(X_raw, y_raw)
+    y_hat = clf.predict_proba(X_raw)
+
+    times, scores = interpret_data(X_raw, y_hat, clf.predict_proba)
+    print('%9.4fs %9.4fs %9.4fs' % (min(times), sum(times) / len(times), max(times)))
+    print('%9.4f %9.4f% 9.4f' % (min(scores), sum(scores) / len(scores), max(scores)))

--- a/benchmark/text_perf.py
+++ b/benchmark/text_perf.py
@@ -1,0 +1,37 @@
+import time
+import sklearn
+import sklearn.ensemble
+import sklearn.metrics
+from sklearn.datasets import fetch_20newsgroups
+from sklearn.pipeline import make_pipeline
+from lime.lime_text import LimeTextExplainer
+
+
+def interpret_data(X, y, func, class_names):
+    explainer = LimeTextExplainer(class_names=class_names)
+    times, scores = [], []
+    for r_idx in range(10):
+        start_time = time.time()
+        exp = explainer.explain_instance(newsgroups_test.data[r_idx], func, num_features=6)
+        times.append(time.time() - start_time)
+        scores.append(exp.score)
+        print('...')
+
+    return times, scores
+
+if __name__ == '__main__':
+    categories = ['alt.atheism', 'soc.religion.christian']
+    newsgroups_train = fetch_20newsgroups(subset='train', categories=categories)
+    newsgroups_test = fetch_20newsgroups(subset='test', categories=categories)
+    class_names = ['atheism', 'christian']
+
+    vectorizer = sklearn.feature_extraction.text.TfidfVectorizer(lowercase=False)
+    train_vectors = vectorizer.fit_transform(newsgroups_train.data)
+    test_vectors = vectorizer.transform(newsgroups_test.data)
+    rf = sklearn.ensemble.RandomForestClassifier(n_estimators=500)
+    rf.fit(train_vectors, newsgroups_train.target)
+    pred = rf.predict(test_vectors)
+    sklearn.metrics.f1_score(newsgroups_test.target, pred, average='binary')
+    c = make_pipeline(vectorizer, rf)
+
+    interpret_data(train_vectors, newsgroups_train.target, c.predict_proba, class_names)


### PR DESCRIPTION
## Background

We've been doing some work with LIME in relatively high-dimension problems (1000+ features), and have found that the current distance metric doesn't tend to perform well in that context [[related paper](http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.23.7409&rep=rep1&type=pdf)].  For very high dimensions, the euclidian distance is inflated to a large value, which given the kernel you are using:

`sqrt(exp(-d^2/k^2))`

Can be tuned by using very large kernel widths.  A simple example is the classification problem defined by using a default sklearn RandomForestClassifier on a dataset created with:

`sklearn.datasets.make_classification(n_classes=2, n_features=1000, n_samples=1000)`

In this case, a kernel width of 3 leads to the weight for the first record (the sample being interpreted itself) having a weight of 1, while all other samples are weighted at near 0, which of course leads to a bad interpretation.  Using very large kernel_widths increases the average score (~0.3 with a width of 10e9), but in general, I think this just isn't the best metric for higher dimension problems.  I've tried some other metrics, and without tuning the kernel width, they are performing much better than euclidian norm can do with a well tuned kernel width).

Just for reference, using the default kernel width of 3, and changing only distance metric on the above problem led to a range of scores between 0 and 1, with cityblock and L1 distance performing best of those I tried, at the cost of a small slowdown.  The scores per sample within each run had low variance, but the scores per metric differed quite a bit, which indicates to me that this is an important tuning parameter.  Chebyshev distance performed better than euclidean but not the best, and was slightly faster than the current euclidean code.

## Changes

This PR exposes an option to the user to specify a metric from this pretty comprehensive list: [sklearn pairwise distances](http://scikit-learn.org/stable/modules/generated/sklearn.metrics.pairwise.pairwise_distances.html), defaulting to euclidian for tabular and cosine for text which is the the same as the current measures.  So for existing users, this changes nothing, but optionally, for cases like I described above, you'll be able to use different metrics.

I've also included a benchmarks folder which has a script for each of the explainers that loops through a sample dataset and records scores and times, it may be useful for other similar optimizations.


