### PR TITLE
High Dimensionality improvements

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -164,7 +164,8 @@ class LimeTabularExplainer(object):
 
     def explain_instance(self, data_row, classifier_fn, labels=(1,),
                          top_labels=None, num_features=10, num_samples=5000,
-                         distance_metric='euclidean', model_regressor=None):
+                         distance_metric='euclidean',
+                         model_regressor=None, high_dim=False):
         """Generates explanations for a prediction.
 
         First, we generate neighborhood data by randomly perturbing features
@@ -193,6 +194,10 @@ class LimeTabularExplainer(object):
             explanations.
         """
         data, inverse = self.__data_inverse(data_row, num_samples)
+        if high_dim:
+            # remove the first row
+            data = np.delete(data, 0, 0)
+            inverse = np.delete(inverse, 0, 0)
         scaled_data = (data - self.scaler.mean_) / self.scaler.scale_
 
         distances = sklearn.metrics.pairwise_distances(

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import sklearn.datasets
+from sklearn import datasets
 from sklearn.datasets import load_iris
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import Lasso
@@ -73,6 +74,27 @@ class TestLimeTabular(unittest.TestCase):
 
         exp = explainer.explain_instance(test[i], rf.predict_proba,
                                          num_features=2)
+        self.assertIsNotNone(exp)
+
+    def test_lime_explainer_high_dim(self):
+        np.random.seed(1)
+        feature_names = ['feature_{0}'.format(str(x))
+                         for x in list(range(2000))]
+        X, y = datasets.make_classification(n_features=2000, n_samples=1000)
+        train, test, labels_train, labels_test = (
+            sklearn.cross_validation.train_test_split(X, y,
+                                                      train_size=0.80))
+
+        rf = RandomForestClassifier(n_estimators=500)
+        rf.fit(train, labels_train)
+        i = np.random.randint(0, test.shape[0])
+
+        explainer = LimeTabularExplainer(train,
+                                         feature_names=feature_names,
+                                         discretize_continuous=False)
+
+        exp = explainer.explain_instance(test[i], rf.predict_proba,
+                                         num_features=2, high_dim=False)
         self.assertIsNotNone(exp)
 
 if __name__ == '__main__':


### PR DESCRIPTION
On high dimensional data pairwises distances essentially go to zero, due to the main data row being in
the neighborhood data. If we exclude the first row, the distances should not fall to zero