### PR TITLE
Add LICENSE to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include lime/*.js
+include LICENSE


### PR DESCRIPTION
Add `LICENSE` to the `MANIFEST.in` file so that they will be included in sdists and other packages.

This came up during packaging of `lime` for `conda-forge`.

Also please submit a new release to `pypi` so this change will be tracked.
