### PR TITLE
bug fix in charts rendering for two-classes problems

### DIFF
--- a/lime/bundle.js
+++ b/lime/bundle.js
@@ -125,7 +125,7 @@ var lime =
 	      var names = ['NOT ' + this.names[label], this.names[label]];
 	      if (this.names.length == 2) {
 	        colors = [this.colors_i(0), this.colors_i(1)];
-	        names = this.names;
+	        names = [this.names[Math.abs(label-1)], this.names[label]];
 	      }
 	      var plot = new _bar_chart2.default(svg, exp, true, names, colors, true, 10);
 	      svg.style('height', plot.svg_height);


### PR DESCRIPTION
It seems the code was implemented assuming that the labels sequence would be always: `Not-label`  -> `label` .

But, when number of classes == 2, the code uses the labels natural order (L128):

`label1` -> `label2`

So, that potentially does not match with the terms using in explanation. The fix is forcing the target/current label into the right side. 

Not sure if it is the best way to do that though. It is working for me so far like this.