### PR TITLE
Allow feature_names to be None

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -146,8 +146,6 @@ class LimeTabularExplainer(object):
         """
         self.random_state = check_random_state(random_state)
         self.mode = mode
-        self.categorical_names = categorical_names
-        self.categorical_features = categorical_features
         self.categorical_names = categorical_names or {}
         self.categorical_features = categorical_features or []
         self.feature_names = feature_names or [str(i) for i in range(training_data.shape[1])]

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -146,15 +146,11 @@ class LimeTabularExplainer(object):
         """
         self.random_state = check_random_state(random_state)
         self.mode = mode
-        self.feature_names = list(feature_names)
         self.categorical_names = categorical_names
         self.categorical_features = categorical_features
-        if self.categorical_names is None:
-            self.categorical_names = {}
-        if self.categorical_features is None:
-            self.categorical_features = []
-        if self.feature_names is None:
-            self.feature_names = [str(i) for i in range(training_data.shape[1])]
+        self.categorical_names = categorical_names or {}
+        self.categorical_features = categorical_features or []
+        self.feature_names = feature_names or [str(i) for i in range(training_data.shape[1])]
 
         self.discretizer = None
         if discretize_continuous:

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -535,6 +535,11 @@ class TestLimeTabular(unittest.TestCase):
 
         self.assertFalse(exp_1.as_map() != exp_2.as_map())
 
+    def testFeatureNames(self):
+        explainer = LimeTabularExplainer(training_data=np.array([[0., 1.], [1., 0.]]))
+
+        self.assertEqual(explainer.feature_names, ['0', '1'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There is currently an attempt to create a list of feature names if one is not provided via `[str(i) for i in range(training_data.shape[1])]`, but this is thwarted by the line above: `self.feature_names = list(feature_names)`. This of course fails if `feature_names` is None. Example:

```python
import numpy as np
from lime.lime_tabular import LimeTabularExplainer

explainer = LimeTabularExplainer(training_data=np.array([[0., 1.], [1., 0.]]))
```

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-28-712821f53381> in <module>()
----> 1 explainer = LimeTabularExplainer(training_data=np.array([[0., 1.], [1., 0.]]))

~/.envs/lime/lib/python3.6/site-packages/lime-0.1.1.25-py3.6.egg/lime/lime_tabular.py in __init__(self, training_data, mode, training_labels, feature_names, categorical_features, categorical_names, kernel_width, verbose, class_names, feature_selection, discretize_continuous, discretizer, random_state)
    147         self.random_state = check_random_state(random_state)
    148         self.mode = mode
--> 149         self.feature_names = list(feature_names)
    150         self.categorical_names = categorical_names
    151         self.categorical_features = categorical_features

TypeError: 'NoneType' object is not iterable
```

I added a test for this.

I also cleaned up the `None` checking.