### PR TITLE
Support numpy arrays for categorical_features and feature_names

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -147,11 +147,14 @@ class LimeTabularExplainer(object):
         self.random_state = check_random_state(random_state)
         self.mode = mode
         self.categorical_names = categorical_names or {}
-        self.categorical_features = [] if categorical_features is None else list(categorical_features)
+
+        if categorical_features is None:
+            categorical_features = []
         if feature_names is None:
-            self.feature_names = [str(i) for i in range(training_data.shape[1])]
-        else:
-            self.feature_names = list(feature_names)
+            feature_names = [str(i) for i in range(training_data.shape[1])]
+
+        self.categorical_features = list(categorical_features)
+        self.feature_names = list(feature_names)
 
         self.discretizer = None
         if discretize_continuous:

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -147,8 +147,11 @@ class LimeTabularExplainer(object):
         self.random_state = check_random_state(random_state)
         self.mode = mode
         self.categorical_names = categorical_names or {}
-        self.categorical_features = categorical_features or []
-        self.feature_names = feature_names or [str(i) for i in range(training_data.shape[1])]
+        self.categorical_features = [] if categorical_features is None else list(categorical_features)
+        if feature_names is None:
+            self.feature_names = [str(i) for i in range(training_data.shape[1])]
+        else:
+            self.feature_names = list(feature_names)
 
         self.discretizer = None
         if discretize_continuous:
@@ -170,7 +173,7 @@ class LimeTabularExplainer(object):
                 raise ValueError('''Discretizer must be 'quartile',''' +
                                  ''' 'decile', 'entropy' or a''' +
                                  ''' BaseDiscretizer instance''')
-            self.categorical_features = range(training_data.shape[1])
+            self.categorical_features = list(range(training_data.shape[1]))
             discretized_training_data = self.discretizer.discretize(
                     training_data)
 

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -537,21 +537,24 @@ class TestLimeTabular(unittest.TestCase):
 
     def testFeatureNamesAndCategoricalFeats(self):
         training_data = np.array([[0., 1.], [1., 0.]])
-        
+
         explainer = LimeTabularExplainer(training_data=training_data)
         self.assertEqual(explainer.feature_names, ['0', '1'])
         self.assertEqual(explainer.categorical_features, [0, 1])
-        
-        explainer = LimeTabularExplainer(training_data=training_data, feature_names=np.array(['one', 'two']))
+
+        explainer = LimeTabularExplainer(
+            training_data=training_data,
+            feature_names=np.array(['one', 'two'])
+        )
         self.assertEqual(explainer.feature_names, ['one', 'two'])
-        
+
         explainer = LimeTabularExplainer(
             training_data=training_data,
             categorical_features=np.array([0]),
             discretize_continuous=False
         )
         self.assertEqual(explainer.categorical_features, [0])
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -535,11 +535,23 @@ class TestLimeTabular(unittest.TestCase):
 
         self.assertFalse(exp_1.as_map() != exp_2.as_map())
 
-    def testFeatureNames(self):
-        explainer = LimeTabularExplainer(training_data=np.array([[0., 1.], [1., 0.]]))
-
+    def testFeatureNamesAndCategoricalFeats(self):
+        training_data = np.array([[0., 1.], [1., 0.]])
+        
+        explainer = LimeTabularExplainer(training_data=training_data)
         self.assertEqual(explainer.feature_names, ['0', '1'])
-
+        self.assertEqual(explainer.categorical_features, [0, 1])
+        
+        explainer = LimeTabularExplainer(training_data=training_data, feature_names=np.array(['one', 'two']))
+        self.assertEqual(explainer.feature_names, ['one', 'two'])
+        
+        explainer = LimeTabularExplainer(
+            training_data=training_data,
+            categorical_features=np.array([0]),
+            discretize_continuous=False
+        )
+        self.assertEqual(explainer.categorical_features, [0])
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
In https://github.com/marcotcr/lime/pull/132 I did not realize people were sometimes passing in numpy arrays for `categorical_features` and `feature_names`. While that's not technically following the documentation (both args ask for lists), I don't want to break people's workflows, so this brings back the more defensive behavior that supports lists or numpy arrays.

I added more tests to make sure this behavior is preserved!