### PR TITLE
Remove hardcoded feature count keys

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -197,17 +197,14 @@ class LimeTabularExplainer(object):
         self.feature_frequencies = {}
 
         for feature in self.categorical_features:
-            feature_count = collections.defaultdict(lambda: 0.0)
-            column = training_data[:, feature]
             if self.discretizer is not None:
                 column = discretized_training_data[:, feature]
-                feature_count[0] = 0.
-                feature_count[1] = 0.
-                feature_count[2] = 0.
-                feature_count[3] = 0.
-            for value in column:
-                feature_count[value] += 1
+            else:
+                column = training_data[:, feature]
+
+            feature_count = collections.Counter(column)
             values, frequencies = map(list, zip(*(feature_count.items())))
+
             self.feature_values[feature] = values
             self.feature_frequencies[feature] = (np.array(frequencies) /
                                                  sum(frequencies))

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -207,7 +207,7 @@ class LimeTabularExplainer(object):
 
             self.feature_values[feature] = values
             self.feature_frequencies[feature] = (np.array(frequencies) /
-                                                 sum(frequencies))
+                                                 float(sum(frequencies)))
             self.scaler.mean_[feature] = 0
             self.scaler.scale_[feature] = 1
 

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -555,7 +555,7 @@ class TestLimeTabular(unittest.TestCase):
             discretize_continuous=False
         )
         self.assertEqual(explainer.categorical_features, [0])
-        
+
     def testFeatureValues(self):
         training_data = np.array([
             [0, 0, 2],

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -5,6 +5,7 @@ import sklearn # noqa
 import sklearn.datasets
 import sklearn.ensemble
 import sklearn.linear_model # noqa
+from numpy.testing import assert_array_equal
 from sklearn.datasets import load_iris, make_classification
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.linear_model import Lasso
@@ -554,6 +555,27 @@ class TestLimeTabular(unittest.TestCase):
             discretize_continuous=False
         )
         self.assertEqual(explainer.categorical_features, [0])
+        
+    def testFeatureValues(self):
+        training_data = np.array([
+            [0, 0, 2],
+            [1, 1, 0],
+            [0, 2, 2],
+            [1, 3, 0]
+        ])
+
+        explainer = LimeTabularExplainer(
+            training_data=training_data,
+            categorical_features=[0, 1, 2]
+        )
+
+        self.assertEqual(set(explainer.feature_values[0]), {0, 1})
+        self.assertEqual(set(explainer.feature_values[1]), {0, 1, 2, 3})
+        self.assertEqual(set(explainer.feature_values[2]), {0, 2})
+
+        assert_array_equal(explainer.feature_frequencies[0], np.array([.5, .5]))
+        assert_array_equal(explainer.feature_frequencies[1], np.array([.25, .25, .25, .25]))
+        assert_array_equal(explainer.feature_frequencies[2], np.array([.5, .5]))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It looks like there are some remnants in the code from when [quartile discretization was the only option](https://github.com/marcotcr/lime/commit/bc0e08ca9f3c3508375aebb4f6d4b8c04141fa84). The keys were hardcoded to 0, 1, 2, 3. This leads to incorrect `feature_values` and `feature_frequencies` properties on the explainer:

```python
import numpy as np
from lime.lime_tabular import LimeTabularExplainer

training_data = np.array([
    [0, 0, 8],
    [4, 5, 0],
    [0, 6, 8],
    [4, 7, 0]
])

explainer = LimeTabularExplainer(
    training_data=training_data,
    categorical_features=[0, 1, 2]
)
```

```
explainer.feature_values
```
```
{0: [0, 1, 2, 3, 4], 1: [0, 1, 2, 3, 5, 6, 7], 2: [0, 1, 2, 3, 8]}
```

```
explainer.feature_frequencies
```
```
{0: array([ 0.5,  0. ,  0. ,  0. ,  0.5]), 1: array([ 0.25,  0.  ,  0.  ,  0.  ,  0.25,  0.25,  0.25]), 2: array([ 0.5,  0. ,  0. ,  0. ,  0.5])}
```

I think this was mostly harmless as the frequency of 0 for the unseen values would mean they're never chosen by np.random.choice later when building the synthetic data. But regardless it would be nice to rely on these properties for an accurate way to see the categorical values and their frequencies.

With the fix:

```
explainer.feature_values
```
```
{0: [0, 4], 1: [0, 5, 6, 7], 2: [8, 0]}
```

```
explainer.feature_frequencies
```
```
{0: array([ 0.5,  0.5]), 1: array([ 0.25,  0.25,  0.25,  0.25]), 2: array([ 0.5,  0.5])}
```
