### PR TITLE
Allow custom tokenization in LimeTextExplainer

### DIFF
--- a/lime/tests/test_lime_text.py
+++ b/lime/tests/test_lime_text.py
@@ -142,10 +142,11 @@ class TestLimeText(unittest.TestCase):
 
     def test_indexed_string_regex(self):
         s = 'Please, take your time. Please'
-        tokenized_string = np.array(['Please', 'take', 'your', 'time', 'Please'])
+        tokenized_string = np.array(
+            ['Please', ', ', 'take', ' ', 'your', ' ', 'time', '. ', 'Please'])
         inverse_vocab = ['Please', 'take', 'your', 'time']
-        start_positions = [0, 6, 10, 14, 18]
-        positions = [[0, 4], [1], [2], [3]]
+        start_positions = [0, 6, 8, 12, 13, 17, 18, 22, 24]
+        positions = [[0, 8], [2], [4], [6]]
         indexed_string = IndexedString(s)
 
         self.assertTrue(np.array_equal(indexed_string.as_np, tokenized_string))
@@ -157,7 +158,7 @@ class TestLimeText(unittest.TestCase):
         s = 'aabbccddaa'
 
         def tokenizer(string):
-            return [string[i] + string[i+1] for i in range(0, len(string) - 1, 2)]
+            return [string[i] + string[i + 1] for i in range(0, len(string) - 1, 2)]
 
         tokenized_string = np.array(['aa', 'bb', 'cc', 'dd', 'aa'])
         inverse_vocab = ['aa', 'bb', 'cc', 'dd']
@@ -171,10 +172,10 @@ class TestLimeText(unittest.TestCase):
         self.assertTrue(np.array_equal(indexed_string.positions, positions))
 
     def test_indexed_string_inverse_removing_tokenizer(self):
-        s = 'This is a good movie. This is a great movie'
+        s = 'This is a good movie. This, it is a great movie.'
 
         def tokenizer(string):
-            return re.split(r'(?:\W)|$', string)
+            return re.split(r'(?:\W+)|$', string)
 
         indexed_string = IndexedString(s, tokenizer)
 

--- a/lime/tests/test_lime_text.py
+++ b/lime/tests/test_lime_text.py
@@ -11,7 +11,7 @@ from sklearn.pipeline import make_pipeline
 import numpy as np
 
 from lime.lime_text import LimeTextExplainer
-from lime.lime_text import IndexedCharacters
+from lime.lime_text import IndexedCharacters, IndexedString
 
 
 class TestLimeText(unittest.TestCase):
@@ -138,6 +138,34 @@ class TestLimeText(unittest.TestCase):
         self.assertTrue(np.array_equal(ic.string_start, np.arange(len(s))))
         self.assertTrue(ic.inverse_vocab == list(s))
         self.assertTrue(np.array_equal(ic.positions, np.arange(len(s))))
+
+    def test_indexed_string_regex(self):
+        s = 'Please, take your time. Please'
+        tokenized_string = np.array(['Please', 'take', 'your', 'time', 'Please'])
+        inverse_vocab = ['Please', 'take', 'your', 'time']
+        start_positions = [0, 6, 10, 14, 18]
+        positions = [[0, 4], [1], [2], [3]]
+        indexed_string = IndexedString(s)
+
+        self.assertTrue(np.array_equal(indexed_string.as_np, tokenized_string))
+        self.assertTrue(np.array_equal(indexed_string.string_start, start_positions))
+        self.assertTrue(indexed_string.inverse_vocab == inverse_vocab)
+        self.assertTrue(np.array_equal(indexed_string.positions, positions))
+
+    def test_indexed_string_callable(self):
+        s = 'aabbccddaa'
+        tokenizer = lambda string: [string[i] + string[i+1] for i in range(0, len(string) - 1, 2)]
+        tokenized_string = np.array(['aa', 'bb', 'cc', 'dd', 'aa'])
+        inverse_vocab = ['aa', 'bb', 'cc', 'dd']
+        start_positions = [0, 2, 4, 6, 8]
+        positions = [[0, 4], [1], [2], [3]]
+        indexed_string = IndexedString(s, tokenizer)
+
+        self.assertTrue(np.array_equal(indexed_string.as_np, tokenized_string))
+        self.assertTrue(np.array_equal(indexed_string.string_start, start_positions))
+        self.assertTrue(indexed_string.inverse_vocab == inverse_vocab)
+        self.assertTrue(np.array_equal(indexed_string.positions, positions))
+
 
 
 if __name__ == '__main__':

--- a/lime/tests/test_lime_text.py
+++ b/lime/tests/test_lime_text.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 
 import sklearn # noqa
@@ -168,6 +169,22 @@ class TestLimeText(unittest.TestCase):
         self.assertTrue(np.array_equal(indexed_string.string_start, start_positions))
         self.assertTrue(indexed_string.inverse_vocab == inverse_vocab)
         self.assertTrue(np.array_equal(indexed_string.positions, positions))
+
+    def test_indexed_string_inverse_removing_tokenizer(self):
+        s = 'This is a good movie. This is a great movie'
+
+        def tokenizer(string):
+            return re.split(r'(?:\W)|$', string)
+
+        indexed_string = IndexedString(s, tokenizer)
+
+        self.assertEqual(s, indexed_string.inverse_removing([]))
+
+    def test_indexed_string_inverse_removing_regex(self):
+        s = 'This is a good movie. This is a great movie'
+        indexed_string = IndexedString(s)
+
+        self.assertEqual(s, indexed_string.inverse_removing([]))
 
 
 if __name__ == '__main__':

--- a/lime/tests/test_lime_text.py
+++ b/lime/tests/test_lime_text.py
@@ -154,7 +154,10 @@ class TestLimeText(unittest.TestCase):
 
     def test_indexed_string_callable(self):
         s = 'aabbccddaa'
-        tokenizer = lambda string: [string[i] + string[i+1] for i in range(0, len(string) - 1, 2)]
+
+        def tokenizer(string):
+            return [string[i] + string[i+1] for i in range(0, len(string) - 1, 2)]
+
         tokenized_string = np.array(['aa', 'bb', 'cc', 'dd', 'aa'])
         inverse_vocab = ['aa', 'bb', 'cc', 'dd']
         start_positions = [0, 2, 4, 6, 8]
@@ -165,7 +168,6 @@ class TestLimeText(unittest.TestCase):
         self.assertTrue(np.array_equal(indexed_string.string_start, start_positions))
         self.assertTrue(indexed_string.inverse_vocab == inverse_vocab)
         self.assertTrue(np.array_equal(indexed_string.positions, positions))
-
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
In reference to #192, this pull request adds functionality and tests that allow passing in a callable as the `split_expression` to `LimeTextExplainer`. The changes in this PR can be summarized as follows:

- Allowing passing functions to the `LimeTextExplainer` for custom tokenization. The callable should accept a string and return a list of tokens.
- Tests for the `IndexedString` class, which is where the `split_expression` eventually is used. 
- changing the regex splitting functionality to use non-capturing groups. This allows us not to build a `non_vocabulary` since the separation characters, as defined in the regex, no longer appear in the split list, and therefore no longer need to be filtered out. This also allows for the same kind of iteration between the callable tokenization and the regex tokenization. 

This will close #192.