### PR TITLE
Fix local variable unassigned error

### DIFF
--- a/lime/submodular_pick.py
+++ b/lime/submodular_pick.py
@@ -57,7 +57,8 @@ class SubmodularPick(object):
                 all_indices = np.arange(len(data))
                 np.random.shuffle(all_indices)
                 sample_indices = all_indices[:sample_size]
-            elif method == 'full':
+            # elif method == 'full':
+            else:
                 sample_indices = np.arange(len(data))
 
             # Generate Explanations


### PR DESCRIPTION
When submodular_pick.py was run in my computer with Python3.6, I met an unboundlocal error 

>local variable 'sample_indices' referenced before assignment. .

 
In the source code of **lime\submodular_pick.py** , the variable **`sample_indices`** is not assigned before referenced if there exists no appropriate **`method`**. 
I delete `elif  method == 'full'` and add `else` instead. 