### PR TITLE
Fixed LimeTabularExplainer's feature_frequencies method

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -217,7 +217,7 @@ class LimeTabularExplainer(object):
                 column = training_data[:, feature]
 
             feature_count = collections.Counter(column)
-            values, frequencies = map(list, zip(*(feature_count.items())))
+            values, frequencies = map(list, zip(*(sorted(feature_count.items()))))
 
             self.feature_values[feature] = values
             self.feature_frequencies[feature] = (np.array(frequencies) /


### PR DESCRIPTION
The current implementation on finding feature_frequencies on LimeTabularExplainer will cause bugs as collection.Counter stores in decreasing number of occurences by default. To fix this, sort feature_count by increasing key.

See issue #281 