### PR TITLE
Applied speedups to undiscretize function, as well as some others

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -250,7 +250,6 @@ class LimeTabularExplainer(object):
         self.class_names = class_names
 
         # Though set has no role to play if training data stats are provided
-        self.scaler = None
         self.scaler = sklearn.preprocessing.StandardScaler(with_mean=False)
         self.scaler.fit(training_data)
         self.feature_values = {}
@@ -288,7 +287,7 @@ class LimeTabularExplainer(object):
         valid_stat_keys = ["means", "mins", "maxs", "stds", "feature_values", "feature_frequencies"]
         missing_keys = list(set(valid_stat_keys) - set(stat_keys))
         if len(missing_keys) > 0:
-            raise Exception("Missing keys in training_data_stats. Details:" % (missing_keys))
+            raise Exception("Missing keys in training_data_stats. Details: %s" % (missing_keys))
 
     def explain_instance(self,
                          data_row,
@@ -537,8 +536,7 @@ class LimeTabularExplainer(object):
             freqs = self.feature_frequencies[column]
             inverse_column = self.random_state.choice(values, size=num_samples,
                                                       replace=True, p=freqs)
-            binary_column = np.array([1 if x == first_row[column]
-                                      else 0 for x in inverse_column])
+            binary_column = (inverse_column == first_row[column]).astype(int)
             binary_column[0] = 1
             inverse_column[0] = data[0, column]
             data[:, column] = binary_column

--- a/lime/tests/test_discretize.py
+++ b/lime/tests/test_discretize.py
@@ -1,3 +1,4 @@
+import unittest
 from unittest import TestCase
 
 import numpy as np
@@ -170,3 +171,6 @@ class TestDiscretize(TestCase):
                  '1.75 < petal width (cm) <= 1.85',
                  'petal width (cm) > 1.85']},
             discretizer.names)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
First of all thanks for the great library :smile: 

I was doing some profiling of my code and noticed that the bottleneck was the undiscretize function in the LimeTablularExplainer. I have had a go at implementing a speedup by doing most of the calculations in numpy and seem to be getting an overall speedup of x4 when running the benchmark/table_perf.py script with discretize_continuous=True (which is the default for LimetabularExplainer).

In this PR:
- vectorized the get_undiscretize_value function to allow it to
work on a whole array of values at once, getting around a x3 speedup
for explain_instance
- fixed a broken format string in LimeTabularExplainer.validate_training_data_stats
- converted a list comprehension in LimeTabularExplainer.__data_inverse into a
numpy vectorized comparison to remove another bottleneck.
- added unittest.main to test_discretize for convenience

All the tests pass and I have validated the results on some test notebooks using some toy datasets.

Thanks