### PR TITLE
Add a feature filter before feature selection

### DIFF
--- a/lime/lime_base.py
+++ b/lime/lime_base.py
@@ -71,13 +71,14 @@ class LimeBase(object):
     def feature_selection(self, data, labels, weights, num_features, method, feature_names=None, use_feature_names=None):
         """Selects features for the model. see explain_instance_with_data to
            understand the parameters."""
+        if use_feature_names is not None:
+            use_feature_index = []
+            for f in use_feature_names:
+                use_feature_index.append(feature_names.index(f))
+            data = data[:, use_feature_index]
+
         if method == 'none':
             return np.array(range(data.shape[1]))
-        if method == 'fixed':
-            used_features = []
-            for f in use_feature_names:
-                used_features.append(feature_names.index(f))
-            return used_features
         elif method == 'forward_selection':
             return self.forward_selection(data, labels, weights, num_features)
         elif method == 'highest_weights':
@@ -171,12 +172,11 @@ class LimeBase(object):
                 'none': uses all features, ignores num_features
                 'auto': uses forward_selection if num_features <= 6, and
                     'highest_weights' otherwise.
-                'fixed': uses fixed features which passed by 'use_features'.
             model_regressor: sklearn regressor to use in explanation.
                 Defaults to Ridge regression if None. Must have
                 model_regressor.coef_ and 'sample_weight' as a parameter
                 to model_regressor.fit()
-            exclude_features: exclude features when select features.
+            use_feature_names: use features when select features.
 
         Returns:
             (intercept, exp, score, local_pred):

--- a/lime/lime_base.py
+++ b/lime/lime_base.py
@@ -68,11 +68,16 @@ class LimeBase(object):
             used_features.append(best)
         return np.array(used_features)
 
-    def feature_selection(self, data, labels, weights, num_features, method):
+    def feature_selection(self, data, labels, weights, num_features, method, feature_names=None, use_feature_names=None):
         """Selects features for the model. see explain_instance_with_data to
            understand the parameters."""
         if method == 'none':
             return np.array(range(data.shape[1]))
+        if method == 'fixed':
+            used_features = []
+            for f in use_feature_names:
+                used_features.append(feature_names.index(f))
+            return used_features
         elif method == 'forward_selection':
             return self.forward_selection(data, labels, weights, num_features)
         elif method == 'highest_weights':
@@ -142,6 +147,8 @@ class LimeBase(object):
                                    label,
                                    num_features,
                                    feature_selection='auto',
+                                   feature_names=None,
+                                   use_feature_names=None,
                                    model_regressor=None):
         """Takes perturbed data, labels and distances, returns explanation.
 
@@ -164,10 +171,12 @@ class LimeBase(object):
                 'none': uses all features, ignores num_features
                 'auto': uses forward_selection if num_features <= 6, and
                     'highest_weights' otherwise.
+                'fixed': uses fixed features which passed by 'use_features'.
             model_regressor: sklearn regressor to use in explanation.
                 Defaults to Ridge regression if None. Must have
                 model_regressor.coef_ and 'sample_weight' as a parameter
                 to model_regressor.fit()
+            exclude_features: exclude features when select features.
 
         Returns:
             (intercept, exp, score, local_pred):
@@ -185,7 +194,9 @@ class LimeBase(object):
                                                labels_column,
                                                weights,
                                                num_features,
-                                               feature_selection)
+                                               feature_selection,
+                                               feature_names,
+                                               use_feature_names)
         if model_regressor is None:
             model_regressor = Ridge(alpha=1, fit_intercept=True,
                                     random_state=self.random_state)

--- a/lime/lime_base.py
+++ b/lime/lime_base.py
@@ -68,19 +68,21 @@ class LimeBase(object):
             used_features.append(best)
         return np.array(used_features)
 
-    def feature_selection(self, data, labels, weights, num_features, method, feature_names=None, use_feature_names=None):
+    def feature_selection(self, datas, labels, weights, num_features, method, feature_names=None, use_feature_names=None):
         """Selects features for the model. see explain_instance_with_data to
            understand the parameters."""
+        feature_index = np.array(range(datas.shape[1]))
         if use_feature_names is not None:
             use_feature_index = []
             for f in use_feature_names:
                 use_feature_index.append(feature_names.index(f))
-            data = data[:, use_feature_index]
+            data = datas[:, use_feature_index]
+            feature_index = feature_index[use_feature_index]
 
         if method == 'none':
-            return np.array(range(data.shape[1]))
+            return feature_index[list(range(data.shape[1]))]
         elif method == 'forward_selection':
-            return self.forward_selection(data, labels, weights, num_features)
+            return feature_index[self.forward_selection(data, labels, weights, num_features)]
         elif method == 'highest_weights':
             clf = Ridge(alpha=0, fit_intercept=True,
                         random_state=self.random_state)
@@ -111,14 +113,14 @@ class LimeBase(object):
                 else:
                     nnz_indexes = argsort_data[sdata - num_features:sdata][::-1]
                     indices = weighted_data.indices[nnz_indexes]
-                return indices
+                return feature_index[list(indices)]
             else:
                 weighted_data = coef * data[0]
                 feature_weights = sorted(
                     zip(range(data.shape[1]), weighted_data),
                     key=lambda x: np.abs(x[1]),
                     reverse=True)
-                return np.array([x[0] for x in feature_weights[:num_features]])
+                return feature_index[list([x[0] for x in feature_weights[:num_features]])]
         elif method == 'lasso_path':
             weighted_data = ((data - np.average(data, axis=0, weights=weights))
                              * np.sqrt(weights[:, np.newaxis]))
@@ -132,14 +134,15 @@ class LimeBase(object):
                 if len(nonzero) <= num_features:
                     break
             used_features = nonzero
-            return used_features
+            return feature_index[list(used_features)]
         elif method == 'auto':
             if num_features <= 6:
                 n_method = 'forward_selection'
             else:
                 n_method = 'highest_weights'
-            return self.feature_selection(data, labels, weights,
-                                          num_features, n_method)
+            return self.feature_selection(datas, labels, weights,
+                                          num_features, n_method,
+                                          feature_names, use_feature_names)
 
     def explain_instance_with_data(self,
                                    neighborhood_data,

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -297,7 +297,8 @@ class LimeTabularExplainer(object):
                          num_features=10,
                          num_samples=5000,
                          distance_metric='euclidean',
-                         model_regressor=None):
+                         model_regressor=None,
+                         use_feature_names=None):
         """Generates explanations for a prediction.
 
         First, we generate neighborhood data by randomly perturbing features
@@ -451,7 +452,10 @@ class LimeTabularExplainer(object):
                     label,
                     num_features,
                     model_regressor=model_regressor,
-                    feature_selection=self.feature_selection)
+                    feature_selection=self.feature_selection,
+                    feature_names=self.feature_names,
+                    use_feature_names=use_feature_names
+                    )
 
         if self.mode == "regression":
             ret_exp.intercept[1] = ret_exp.intercept[0]


### PR DESCRIPTION
I just add a filter before selection features.
When I use LIME to get an explanation with a model, I wouldn't get some features are come out in explanation result.
So I implement a filter before the feature selection.
That also can decrease the feature selection's search space to speed up the feature selection.