### PR TITLE
Free up memory during submodular pick

### DIFF
--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -98,7 +98,6 @@ class Explanation(object):
         self.intercept = {}
         self.score = None
         self.local_pred = None
-        self.scaled_data = None
         if mode == 'classification':
             self.class_names = class_names
             self.top_labels = None

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -435,7 +435,6 @@ class LimeTabularExplainer(object):
         ret_exp = explanation.Explanation(domain_mapper,
                                           mode=self.mode,
                                           class_names=self.class_names)
-        ret_exp.scaled_data = scaled_data
         if self.mode == "classification":
             ret_exp.predict_proba = yss[0]
             if top_labels:


### PR DESCRIPTION
This minor fix attempts to free up memory during submodular pick. The intention is to accommodate datasets with large feature spaces or users who wish to set a large sample size. This issue was brought to my attention when conducting a submodular pick from my training set, which is a tabular dataset with hundreds of features. I was getting out-of-memory errors when adding explanations to the list of explanations that is subsequently searched in submodular pick. Below is the suggested fix and its justification:

- Removed the _scaled_data_ member from the _Explanation_ class
     - This member is never referenced after fitting a local linear model to create the _Explanation_
     - In my case, process memory usage increased by hundreds of megabytes per explanation during each iteration of the submodular pick explanation loop

After conducting this fix, I was able to include several more examples in the submodular pick. The size of an individual _Explanation_ is quite small once the _scaled_data_ member is removed, even if the feature space is large. There is still, however, room to improve. While tracking process memory usage during a submodular pick (having already applied this fix), I noticed that memory usage still climbs slowly during this loop. I believe that this may be a consequence of standard Python memory management, but I lack expertise in that area. I invite others to investigate this issue and contribute their ideas.

Finally, thanks to the creators for their hard work on this incredible step towards explainable ML!
