### PR TITLE
Clean up basic usage & multiclass tutorials

### DIFF
--- a/doc/notebooks/Lime - basic usage, two class case.ipynb
+++ b/doc/notebooks/Lime - basic usage, two class case.ipynb
@@ -61,7 +61,7 @@
    "source": [
     "vectorizer = sklearn.feature_extraction.text.TfidfVectorizer(lowercase=False)\n",
     "train_vectors = vectorizer.fit_transform(newsgroups_train.data)\n",
-    "test_vectors = vectorizer.transform(newsgroups_test.data)\n"
+    "test_vectors = vectorizer.transform(newsgroups_test.data)"
    ]
   },
   {
@@ -96,7 +96,7 @@
    ],
    "source": [
     "rf = sklearn.ensemble.RandomForestClassifier(n_estimators=500)\n",
-    "rf.fit(train_vectors, newsgroups_train.target)\n"
+    "rf.fit(train_vectors, newsgroups_train.target)"
    ]
   },
   {
@@ -140,7 +140,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Lime explainers assume that classifiers act on raw text, but sklearn classifiers act on vectorized representation of texts. For this purpose, we use sklearn's pipeline, and implements predict_proba on raw_text lists."
+    "Lime explainers assume that classifiers act on raw text, but sklearn classifiers act on vectorized representation of texts. For this purpose, we use sklearn's pipeline, and implement ````predict_proba```` on raw_text lists."
    ]
   },
   {
@@ -178,7 +178,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we create an explainer object. We pass the class_names as an argument for prettier display."
+    "Now we create an explainer object. We pass the ````class_names```` as an argument for prettier display."
    ]
   },
   {
@@ -336,7 +336,7 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "fig = exp.as_pyplot_figure()\n"
+    "fig = exp.as_pyplot_figure()"
    ]
   },
   {
@@ -54423,7 +54423,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "That's it for this tutorial. Random forests were just an example, this explainer works for any classifier you may want to use, as long as it implements predict_proba."
+    "That's it for this tutorial. Random forests were just an example, this explainer works for any classifier you may want to use, as long as it implements ````predict_proba````."
    ]
   }
  ],

--- a/doc/notebooks/Lime - basic usage, two class case.ipynb
+++ b/doc/notebooks/Lime - basic usage, two class case.ipynb
@@ -10,7 +10,6 @@
    "source": [
     "from __future__ import print_function\n",
     "import lime\n",
-    "import numpy as np\n",
     "import sklearn\n",
     "import sklearn.ensemble\n",
     "import sklearn.metrics"
@@ -152,7 +151,6 @@
    },
    "outputs": [],
    "source": [
-    "from lime import lime_text\n",
     "from sklearn.pipeline import make_pipeline\n",
     "c = make_pipeline(vectorizer, rf)"
    ]
@@ -223,7 +221,7 @@
     "idx = 83\n",
     "exp = explainer.explain_instance(newsgroups_test.data[idx], c.predict_proba, num_features=6)\n",
     "print('Document id: %d' % idx)\n",
-    "print('Probability(christian) =', c.predict_proba([newsgroups_test.data[idx]])[0,1])\n",
+    "print('Probability(christian) =', c.predict_proba([newsgroups_test.data[idx]])[0, 1])\n",
     "print('True class: %s' % class_names[newsgroups_test.target[idx]])"
    ]
   },
@@ -287,12 +285,12 @@
     }
    ],
    "source": [
-    "print('Original prediction:', rf.predict_proba(test_vectors[idx])[0,1])\n",
+    "print('Original prediction:', rf.predict_proba(test_vectors[idx])[0, 1])\n",
     "tmp = test_vectors[idx].copy()\n",
-    "tmp[0,vectorizer.vocabulary_['Posting']] = 0\n",
-    "tmp[0,vectorizer.vocabulary_['Host']] = 0\n",
-    "print('Prediction removing some features:', rf.predict_proba(tmp)[0,1])\n",
-    "print('Difference:', rf.predict_proba(tmp)[0,1] - rf.predict_proba(test_vectors[idx])[0,1])"
+    "tmp[0, vectorizer.vocabulary_['Posting']] = 0\n",
+    "tmp[0, vectorizer.vocabulary_['Host']] = 0\n",
+    "print('Prediction removing some features:', rf.predict_proba(tmp)[0, 1])\n",
+    "print('Difference:', rf.predict_proba(tmp)[0, 1] - rf.predict_proba(test_vectors[idx])[0, 1])"
    ]
   },
   {

--- a/doc/notebooks/Lime - basic usage, two class case.ipynb
+++ b/doc/notebooks/Lime - basic usage, two class case.ipynb
@@ -8,13 +8,12 @@
    },
    "outputs": [],
    "source": [
+    "from __future__ import print_function\n",
     "import lime\n",
-    "import sklearn\n",
     "import numpy as np\n",
     "import sklearn\n",
     "import sklearn.ensemble\n",
-    "import sklearn.metrics\n",
-    "from __future__ import print_function"
+    "import sklearn.metrics"
    ]
   },
   {


### PR DESCRIPTION
Some clean up in the first tutorials :)

typos, formatting, import organization
python3 compatibility by moving from-future-import to the top of the list