### PR TITLE
Fixing issue #506

### DIFF
--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -95,8 +95,8 @@ class Explanation(object):
         self.domain_mapper = domain_mapper
         self.local_exp = {}
         self.intercept = {}
-        self.score = None
-        self.local_pred = None
+        self.score = {}
+        self.local_pred = {}
         if mode == 'classification':
             self.class_names = class_names
             self.top_labels = None

--- a/lime/lime_image.py
+++ b/lime/lime_image.py
@@ -28,7 +28,8 @@ class ImageExplanation(object):
         self.segments = segments
         self.intercept = {}
         self.local_exp = {}
-        self.local_pred = None
+        self.local_pred = {}
+        self.score = {}
 
     def get_image_and_mask(self, label, positive_only=True, negative_only=False, hide_rest=False,
                            num_features=5, min_weight=0.):
@@ -216,7 +217,7 @@ class LimeImageExplainer(object):
         for label in top:
             (ret_exp.intercept[label],
              ret_exp.local_exp[label],
-             ret_exp.score, ret_exp.local_pred) = self.base.explain_instance_with_data(
+             ret_exp.score[label], ret_exp.local_pred[label]) = self.base.explain_instance_with_data(
                 data, labels, distances, label, num_features,
                 model_regressor=model_regressor,
                 feature_selection=self.feature_selection)

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -455,7 +455,7 @@ class LimeTabularExplainer(object):
         for label in labels:
             (ret_exp.intercept[label],
              ret_exp.local_exp[label],
-             ret_exp.score, ret_exp.local_pred) = self.base.explain_instance_with_data(
+             ret_exp.score[label], ret_exp.local_pred[label]) = self.base.explain_instance_with_data(
                     scaled_data,
                     yss,
                     distances,

--- a/lime/lime_text.py
+++ b/lime/lime_text.py
@@ -426,7 +426,7 @@ class LimeTextExplainer(object):
         for label in labels:
             (ret_exp.intercept[label],
              ret_exp.local_exp[label],
-             ret_exp.score, ret_exp.local_pred) = self.base.explain_instance_with_data(
+             ret_exp.score[label], ret_exp.local_pred[label]) = self.base.explain_instance_with_data(
                 data, yss, distances, label, num_features,
                 model_regressor=model_regressor,
                 feature_selection=self.feature_selection)


### PR DESCRIPTION
As discussed in https://github.com/marcotcr/lime/issues/506 `score` and `local_pred` were overwritten. They are now stored as a dict with the label of the class as keys.