### PR TITLE
Remove meaningless try-except

### DIFF
--- a/lime/lime_image.py
+++ b/lime/lime_image.py
@@ -180,10 +180,7 @@ class LimeImageExplainer(object):
             segmentation_fn = SegmentationAlgorithm('quickshift', kernel_size=4,
                                                     max_dist=200, ratio=0.2,
                                                     random_seed=random_seed)
-        try:
-            segments = segmentation_fn(image)
-        except ValueError as e:
-            raise e
+        segments = segmentation_fn(image)
 
         fudged_image = image.copy()
         if hide_color is None:


### PR DESCRIPTION
The caught ValueError is again passed to the outside as an exception. 
Since there is no point in using try-except, we can remove it.