### PR TITLE
FIX MNIST Tutorial with RandomForest

### DIFF
--- a/doc/notebooks/Tutorial - MNIST and RF.ipynb
+++ b/doc/notebooks/Tutorial - MNIST and RF.ipynb
@@ -36,8 +36,8 @@
    },
    "outputs": [],
    "source": [
-    "from sklearn.datasets import fetch_mldata\n",
-    "mnist = fetch_mldata('MNIST original')\n",
+    "from sklearn.datasets import fetch_openml\n",
+    "mnist = fetch_openml('mnist_784')\n",
     "# make each image color so lime_image works correctly\n",
     "X_vec = np.stack([gray2rgb(iimg) for iimg in mnist.data.reshape((-1, 28, 28))],0)\n",
     "y_vec = mnist.target.astype(np.uint8)"

--- a/doc/notebooks/Tutorial - MNIST and RF.ipynb
+++ b/doc/notebooks/Tutorial - MNIST and RF.ipynb
@@ -39,7 +39,7 @@
     "from sklearn.datasets import fetch_openml\n",
     "mnist = fetch_openml('mnist_784')\n",
     "# make each image color so lime_image works correctly\n",
-    "X_vec = np.stack([gray2rgb(iimg) for iimg in mnist.data.reshape((-1, 28, 28))],0)\n",
+    "X_vec = np.stack([gray2rgb(iimg) for iimg in mnist.data.reshape((-1, 28, 28))],0).astype(np.uint8)\n",
     "y_vec = mnist.target.astype(np.uint8)"
    ]
   },


### PR DESCRIPTION
fetch_mldata is deprecated since sklearn 0.20 and was removed in 0.22 as mldata.org is not operational anymore (see https://scikit-learn.org/stable/whats_new/v0.20.html#id26 sections sklearn.datasets, API changes)

The new function is fetch_openml.
Example: 
https://stackoverflow.com/a/54616305/8040287
https://scikit-learn.org/stable/auto_examples/linear_model/plot_sparse_logistic_regression_mnist.html#sphx-glr-auto-examples-linear-model-plot-sparse-logistic-regression-mnist-py

However the data is of type float64, so we need to convert it to integer (warning were raised by matplotlib as indication)