### PR TITLE
Fix endless loop

### DIFF
--- a/lime/js/predict_proba.js
+++ b/lime/js/predict_proba.js
@@ -76,7 +76,7 @@ class PredictProba {
         // todo
         let cur_text = text.text().slice(0, text.text().length - 5);
         text.text(cur_text + '...');
-        if (cur_text === '') {
+        if (cur_text.length <= 3) {
           break
         }
       }


### PR DESCRIPTION
In the `PredictProba` component, text with a length >= 4 with an even number of characters, or text with 3 characters will never meet the condition to break the loop.

This occurred for us when opening a notebook containing cells with the output of `explain_instance` in JupyterLab.

Here's an example with an equivalent algorithm:

```javascript
function tester(message_length) {
  let counter = 0;
  let text = "a".repeat(message_length);

  while (counter < 1000) {
    counter++;

    let sliced = text.slice(0, text.length - 5);
    text = sliced + '...';

    if (sliced === "") {
      return true;
    }
  }

  return false;
}

for (let i = 0; i < 30; i++) {
  if (tester(i)) {
    console.log(`${i} ended`)
  } else {
    console.log(`${i} didn't end`)
  }
}

```
https://jsfiddle.net/rL3v520t/

```
"0 ended"
"1 ended"
"2 ended"
"3 didn't end"
"4 didn't end"
"5 ended"
"6 didn't end"
"7 ended"
"8 didn't end"
"9 ended"
"10 didn't end"
"11 ended"
"12 didn't end"
"13 ended"
"14 didn't end"
"15 ended"
...
```

And with the fix:

```javascript
function tester(message_length) {
  let counter = 0;
  let text = "a".repeat(message_length);

  while (counter < 1000) {
    counter++;

    let sliced = text.slice(0, text.length - 5);
    text = sliced + '...';

    if (sliced.length <= 3) {
      return true;
    }
  }

  return false;
}

for (let i = 0; i < 30; i++) {
  if (tester(i)) {
    console.log(`${i} ended`)
  } else {
    console.log(`${i} didn't end`)
  }
}
```

https://jsfiddle.net/nreh75bf/

```
"0 ended"
"1 ended"
"2 ended"
"3 ended"
"4 ended"
"5 ended"
"6 ended"
"7 ended"
"8 ended"
"9 ended"
"10 ended"
"11 ended"
"12 ended"
"13 ended"
"14 ended"
"15 ended"
...
```