### PR TITLE
fix import of lime.lime_tabular

### DIFF
--- a/doc/notebooks/Latin Hypercube Sampling.ipynb
+++ b/doc/notebooks/Latin Hypercube Sampling.ipynb
@@ -21,8 +21,7 @@
    "outputs": [],
    "source": [
     "# imports \n",
-    "#import lime.lime_tabular\n",
-    "import lime_tabular as lime_tabular\n",
+    "from lime import lime_tabular\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.patches as mpatches \n",


### PR DESCRIPTION
Currently the notebook fails in the statement `import lime_tabular as lime_tabular`.