### PR TITLE
Small fix for error when labels are non-integer

### DIFF
--- a/lime/lime_image.py
+++ b/lime/lime_image.py
@@ -211,12 +211,12 @@ class LimeImageExplainer(object):
             top = np.argsort(labels[0])[-top_labels:]
             ret_exp.top_labels = list(top)
             ret_exp.top_labels.reverse()
-        for label in top:
+        for (lidx, label) in enumerate(top):
             (ret_exp.intercept[label],
              ret_exp.local_exp[label],
              ret_exp.score[label],
              ret_exp.local_pred[label]) = self.base.explain_instance_with_data(
-                data, labels, distances, label, num_features,
+                data, labels, distances, lidx, num_features,
                 model_regressor=model_regressor,
                 feature_selection=self.feature_selection)
         return ret_exp


### PR DESCRIPTION
Hey there,

First of all, let me thank you for your work! Truly great tool!

I was playing around and I wanted to get results from LIME about a binary image classification model, and I stumbled across a small hiccup. When I would set the `labels` parameter to an array of strings, for example `["OK", "NG"]`, I would get an error from `lime_base.py` on line 182 that indices need to be integers or ellipses. The function I was calling is `LimeImageExplainer.explain_instance`, so I figured there was something wrong there. The label is passed as it is, so naturally `"OK"` is not a valid index. I've introduced a simple enumeration over the labels, so I think the rest of the code should work as intended. If I have missed anything, please let me know.

Thank you again!

Cheers.