### PR TITLE
Added support for custom replacement_fn

### DIFF
--- a/lime/lime_text.py
+++ b/lime/lime_text.py
@@ -400,8 +400,8 @@ class LimeTextExplainer(object):
                 prediction probabilities, where k is the number of classes.
                 For ScikitClassifiers , this is classifier.predict_proba.
             replacement_fn: A function which can be specified which defines a replacement strategy. Takes in a
-                list of strings representing the original text as a list (text_as_list: List[str]) and a list of integers
-                which represent which tokens were marked for removal (masks: List[List[int]]). Each List[int] in masks
+                list of strings representing the original text as a list (text_as_list: List[str]) and a list of boolean
+                which represent which tokens were marked for removal (masks: List[List[bool]]). Each List[int] in masks
                 represents one sampled item. Returns a List[str] where each item in List[str] is a modified version of
                 the original text. (By default no replacement is done and text is removed)
             labels: iterable with labels to be explained.
@@ -467,8 +467,8 @@ class LimeTextExplainer(object):
                 takes a string and outputs prediction probabilities. For
                 ScikitClassifier, this is classifier.predict_proba.
             replacement_fn: A function which can be specified which defines a replacement strategy. Takes in a
-                list of strings representing the original text as a list (text_as_list: List[str]) and a list of integers
-                which represent which tokens were marked for removal (masks: List[List[int]]). Each List[int] in masks
+                list of strings representing the original text as a list (text_as_list: List[str]) and a list of bools
+                which represent which tokens were marked for removal (masks: List[List[bool]]). Each List[int] in masks
                 represents one sampled item. Returns a List[str] where each item in List[str] is a modified version of
                 the original text. (By default no replacement is done and text is removed)
             num_samples: size of the neighborhood to learn the linear model

--- a/lime/lime_text.py
+++ b/lime/lime_text.py
@@ -13,7 +13,7 @@ from sklearn.utils import check_random_state
 
 from . import explanation
 from . import lime_base
-
+import math
 
 class TextDomainMapper(explanation.DomainMapper):
     """Maps feature ids to words or word-positions"""
@@ -493,7 +493,11 @@ class LimeTextExplainer(object):
                 x, x[0], metric=distance_metric).ravel() * 100
 
         doc_size = indexed_string.num_words()
-        sample = self.random_state.randint(1, doc_size + 1, num_samples - 1)
+        try:
+            no_replaces = self.random_state.randint(math.floor((doc_size + 1) / 4), math.floor((doc_size + 1) / 3))
+        except ValueError:
+            no_replaces = self.random_state.randint(1, doc_size + 1)
+        sample = [no_replaces for _ in range(num_samples - 1)]
         data = np.ones((num_samples, doc_size))
         data[0] = np.ones(doc_size)
         features_range = range(doc_size)


### PR DESCRIPTION
Rather than removing text which can create oddities, we may want to consider ways to replace tokens that would otherwise be removed. I added a support for a custom replacement_fn, which is similar to the classifier_fn. My particular use case was using T5, as such, I modified the generation of perturbed data to be in batch style rather than going one at a time. 

This solves partially [ #648](https://github.com/marcotcr/lime/issues/648)

Example replacement_fn:

```python
def t5_wrapper(text_as_list: List[str], masks: list[list[bool]]):
    tokenizer = T5Tokenizer.from_pretrained("t5-small")
    model = T5ForConditionalGeneration.from_pretrained("t5-small")
    out_refs = []
    masker_idxs = []
    outs = []
    for mask in masks:
        local_out = ""
        local_out_ref = ""
        local_masker_idx = 0
        for idx in range(len(mask)):
            if mask[idx]:
                local_out += text_as_list[idx]
                local_out_ref += text_as_list[idx]
            else:
                try:
                    local_out += tokenizer.additional_special_tokens[local_masker_idx]
                    local_masker_idx += 1
                except IndexError:
                    continue
        masker_idxs.append(local_masker_idx)
        outs.append(local_out)
        out_refs.append(local_out_ref)

    model.cuda()
    batch_size = 50
    if len(outs) > batch_size:
        input_ids = tokenizer(outs, return_tensors="pt", padding=True, max_length=512, truncation=True)
        model_suggestions = []
        for idx in range(0, len(input_ids.input_ids), batch_size):
            local_inputs = {}
            for key, value in input_ids.items():
                local_inputs[key] = value[idx: idx+batch_size]
            for key, value in local_inputs.items():
                local_inputs[key] = value.cuda()
            outputs = model.generate(**local_inputs)
            model_suggestions.extend(tokenizer.batch_decode(outputs, skip_special_tokens=False))
    else:
        input_ids = tokenizer(outs, return_tensors="pt", padding=True)
        for key, value in input_ids.items():
            input_ids[key] = value.cuda()
        outputs = model.generate(**input_ids)
        model_suggestions = tokenizer.batch_decode(outputs, skip_special_tokens=False)

    inversed_data = []
    for idx, suggestion in enumerate(model_suggestions):
        local_out = outs[idx]
        local_masker_idx = masker_idxs[idx]
        present_tokens = [tokenizer.additional_special_tokens[idx] for idx in range(local_masker_idx) if
                          tokenizer.additional_special_tokens[idx] in suggestion]
        for idx, present in enumerate(present_tokens):
            if idx == len(present_tokens) - 1:
                index = suggestion.find(present)
                start_idx = index + len(present)
                local_out = local_out.replace(present, suggestion[start_idx:])
            else:
                base_index = suggestion.find(present)
                start_idx = base_index + len(present)
                upper_index = suggestion.find(present_tokens[idx + 1])
                local_out = local_out.replace(present, suggestion[start_idx:upper_index])
        for item in tokenizer.additional_special_tokens:
            local_out = local_out.replace(item, "")
        inversed_data.append(local_out)
    return inversed_data
```