### PR TITLE
Pytorch output support in lime_tabular.py

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -359,6 +359,8 @@ class LimeTabularExplainer(object):
         ).ravel()
 
         yss = predict_fn(inverse)
+        if not isinstance(yss, np.ndarray): #pytorch output
+            yss = yss.detach().numpy() 
 
         # for classification, the model needs to provide a list of tuples - classes
         # along with prediction probabilities

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -507,7 +507,6 @@ class LimeTabularExplainer(object):
         else:
             num_cols = data_row.shape[0]
             data = np.zeros((num_samples, num_cols))
-        categorical_features = range(num_cols)
         if self.discretizer is None:
             instance_sample = data_row
             scale = self.scaler.scale_


### PR DESCRIPTION
If 'yss' is output of a pytorch model, then this check is necessary in order to run a pytorch model trained on tabular dataset: if not isinstance(yss, np.ndarray):
     yss = yss.detach().numpy()