### PR TITLE
Add predict_fn_accept_dense_only to explain_instance when input is sparse but model takes dense

### DIFF
--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -305,7 +305,8 @@ class LimeTabularExplainer(object):
                          num_samples=5000,
                          distance_metric='euclidean',
                          model_regressor=None,
-                         sampling_method='gaussian'):
+                         sampling_method='gaussian',
+                         predict_fn_accept_dense_only=False):
         """Generates explanations for a prediction.
 
         First, we generate neighborhood data by randomly perturbing features
@@ -358,8 +359,17 @@ class LimeTabularExplainer(object):
                 metric=distance_metric
         ).ravel()
 
+        is_convert_to_dense = False
+        if sp.sparse.isspmatrix_csr(inverse) and predict_fn_accept_dense_only:
+            inverse = inverse.toarray()
+            is_convert_to_dense = True
+
         yss = predict_fn(inverse)
 
+        if is_convert_to_dense:
+            inverse = sp.sparse.csr_matrix(inverse)
+            is_convert_to_dense = False
+        
         # for classification, the model needs to provide a list of tuples - classes
         # along with prediction probabilities
         if self.mode == "classification":


### PR DESCRIPTION
Add predict_fn_accept_dense_only to explain_instance. 

When data_row (of explain_instance) is scipy.sparse.matrix but the model was NOT trained with scipy.sparse.matrix, the predict_fn_accept_dense_only convert inverse to dense before call predict_fn (and then back to sparse after call predict_fn) 

Bin dbin@lbl.gov