### PR TITLE
Skmultilearn binary relevance produces sparse output.

### DIFF
--- a/lime/lime_text.py
+++ b/lime/lime_text.py
@@ -481,5 +481,10 @@ class LimeTextExplainer(object):
             data[i, inactive] = 0
             inverse_data.append(indexed_string.inverse_removing(inactive))
         labels = classifier_fn(inverse_data)
+
+        # if labels are a sparse matrix, convert to a dense array
+        if sp.sparse.issparse(labels):
+            labels = labels.toarray()
+            
         distances = distance_fn(sp.sparse.csr_matrix(data))
         return data, labels, distances


### PR DESCRIPTION
While trying to explain a skmultilearn binary relevance model It kept throwing an error about output being sparse.

Changed a few lines of code to handle when classifier_fn produces sparse output.